### PR TITLE
Fixes BG issue on Safarii

### DIFF
--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -1,5 +1,5 @@
 //colors
-$bodycolor           : #D24D57;
+$bodycolor           : transparent;
 $black           	 : #000;
 $white               : #fff;
 $color_gray          : #e8e8e8;


### PR DESCRIPTION
Unknown CSS rendoring issue regarding layering of BG image and bg color set on safari.

* Was working as expected on firefox, chrome, opera, etc
* Safari produced issues with how the red BG layer rendered
* Made transparent
* Dodgy fix --> better solution unknown for now
